### PR TITLE
Cleaned up different names for same data

### DIFF
--- a/edit_data.csv
+++ b/edit_data.csv
@@ -1,0 +1,115 @@
+Are you on the waiting list?,Program,Experiences with tools,"Programming and Analytical Experiences [R, data manipulation and modeling]",What is your preferred gender pronoun?,What code/text editor do you use most?,"Programming and Analytical Experiences [R, graphic basics (base, lattice, grid etc. )]","Programming and Analytical Experiences [R, advanced (multivariate data analysis, e.g. spatiotemporal data, visualization and modeling)]",Programming and Analytical Experiences [Reproducible documentation with R (e.g. R Markdown)],"Programming and Analytical Experiences [Matlab, data manipulation, analysis, visualization and modeling]",Programming and Analytical Experiences [Github]
+No,IDSE (master),"R, Excel, SQL, RStudio, ggplot2, Python, Stata, dropbox, google drive (formerly docs)",Confident,she/her,RStudio,Confident,A little,A little,A little,None
+No,Other masters,"R, Excel, RStudio, ggplot2, regular expressions (grep), dropbox, google drive (formerly docs)",Confident,he/him,RStudio,A little,A little,A little,A little,A little
+No,Data Science Certification,"R, Github, Excel, SQL, RStudio, ggplot2, shell (terminal / command line), Python, LaTeX, regular expressions (grep), Sweave/knitr, XML, Web: html css js, dropbox, google drive (formerly docs)",Expert,he/him,Atom,Confident,Confident,Expert,Confident,Confident
+No,IDSE (master),"Excel, Python, Web: html css js, dropbox, google drive (formerly docs)",None,he/him,Sublime,None,None,None,None,None
+No,IDSE (master),"R, SQL, RStudio, C/C++, Python, dropbox, google drive (formerly docs)",Confident,he/him,TextWrangler,Confident,Confident,A little,None,None
+No,IDSE (master),"Matlab, Github, RStudio, C/C++, Python, LaTeX",A little,he/him,Sublime,None,None,A little,A little,A little
+Yes,Statistics (master),"Matlab, R, Github, Excel, RStudio, ggplot2, C/C++, Python, dropbox, google drive (formerly docs)",Confident,he/him,RStudio,Confident,A little,None,Confident,Confident
+No,Other masters,"Matlab, R, Excel, SQL, RStudio, C/C++, Python, Stata",A little,Other,None,None,A little,A little,A little,None
+No,IDSE (master),"Excel, SPSS, Python, Stata, dropbox, google drive (formerly docs)",None,he/him,Stata,None,None,None,None,None
+No,IDSE (master),"R, Github, Excel, SQL, RStudio, shell (terminal / command line), Python, LaTeX, Web: html css js, dropbox, google drive (formerly docs)",Confident,he/him,RStudio,A little,None,Confident,None,A little
+No,IDSE (master),"R, RStudio, Python, LaTeX, dropbox, google drive (formerly docs)",Confident,he/him,RStudio,A little,None,Confident,A little,None
+No,IDSE (master),"R, RStudio, C/C++, Python, Stata, google drive (formerly docs)",Confident,he/him,RStudio,Confident,Confident,Confident,Confident,None
+No,IDSE (master),"Matlab, R, Github, Excel, SQL, RStudio, ggplot2, shell (terminal / command line), SPSS, Python, LaTeX, dropbox, google drive (formerly docs)",Expert,he/him,RStudio,Confident,Expert,Confident,Confident,Confident
+Yes,Statistics (master),"R, Github, SQL, RStudio, ggplot2, Python, dropbox, google drive (formerly docs)",Expert,he/him,RStudio,Confident,Confident,A little,None,Expert
+Yes,Statistics (master),"R, Excel, RStudio, Stata, dropbox",Confident,she/her,RStudio,None,A little,None,A little,A little
+No,Other masters,"R, Excel, RStudio, ggplot2, SPSS, C/C++, Python, Stata, LaTeX, lattice, Sweave/knitr, dropbox, google drive (formerly docs)",Confident,she/her,RStudio,Confident,A little,Expert,A little,A little
+No,Other masters,"Matlab, RStudio, SPSS, C/C++, Python, Stata",Confident,she/her,RStudio,Confident,A little,Confident,A little,A little
+No,IDSE (master),"Matlab, R, Excel, RStudio, Python",Confident,she/her,RStudio,A little,A little,Confident,A little,None
+No,Statistics (master),"R, Excel, RStudio, Python, dropbox, google drive (formerly docs)",Confident,she/her,RStudio,A little,A little,None,None,None
+No,IDSE (master),"R, Excel, SQL, RStudio, ggplot2, Python, Stata, LaTeX, dropbox, google drive (formerly docs)",A little,he/him,RStudio,Confident,A little,Confident,None,None
+No,IDSE (master),"Matlab, R, Github, Excel, SQL, RStudio, ggplot2, SPSS, C/C++, Python, LaTeX, lattice, Sweave/knitr, dropbox, google drive (formerly docs)",Expert,he/him,RStudio,Confident,Confident,Expert,Confident,Confident
+No,IDSE (master),"Matlab, R, Excel, RStudio, SPSS, C/C++, Python, LaTeX, google drive (formerly docs)",Confident,he/him,RStudio,Confident,A little,A little,A little,A little
+No,IDSE (master),"Matlab, R, Github, Excel, SQL, RStudio, ggplot2, shell (terminal / command line), Python, LaTeX, dropbox, google drive (formerly docs)",Confident,he/him,ipython,Confident,Confident,Confident,A little,Confident
+Yes,Statistics (master),"Matlab, R, RStudio",A little,she/her,RStudio,A little,Confident,A little,A little,None
+No,IDSE (master),"R, RStudio, ggplot2, SPSS, Python, google drive (formerly docs)",Confident,she/her,RStudio,A little,A little,None,A little,None
+Yes,Statistics (master),"RStudio, ggplot2, Python, LaTeX",Confident,she/her,RStudio,A little,A little,Confident,None,None
+No,IDSE (master),"R, SQL, RStudio, ggplot2, shell (terminal / command line), SPSS, C/C++, Python, regular expressions (grep), XML, Web: html css js, dropbox, google drive (formerly docs)",Confident,he/him,notepad++,Confident,A little,A little,A little,Confident
+No,IDSE (master),"R, RStudio, C/C++, Python",Confident,he/him,RStudio,A little,A little,Confident,A little,A little
+Yes,Statistics (master),"Matlab, R, Excel, RStudio, SPSS, C/C++, Stata",Confident,he/him,RStudio,A little,A little,None,A little,None
+No,Data Science Certification,"R, Excel, RStudio, dropbox, google drive (formerly docs)",A little,he/him,ipython,A little,None,None,None,A little
+No,Other masters,"R, Github, Excel, SQL, RStudio, ggplot2, shell (terminal / command line), C/C++, Python, LaTeX, regular expressions (grep), Sweave/knitr, XML, Web: html css js, dropbox, google drive (formerly docs)",Confident,he/him,Sublime,Confident,Confident,A little,A little,Confident
+No,IDSE (master),"R, Excel, RStudio, ggplot2, Python, Stata, LaTeX, dropbox, google drive (formerly docs)",Confident,she/her,RStudio,Confident,Confident,A little,A little,A little
+No,Other masters,"R, Excel, SQL, RStudio, Python, dropbox, google drive (formerly docs)",Confident,he/him,RStudio,A little,A little,Confident,None,None
+Yes,Other masters,"Matlab, R, Github, Excel, Python, Web: html css js",Confident,she/her,xcode,Confident,A little,A little,Confident,Confident
+No,IDSE (master),"Matlab, R, Github, Excel, SQL, RStudio, shell (terminal / command line), C/C++, Python, LaTeX, XML, Web: html css js, dropbox, google drive (formerly docs)",Confident,he/him,Sublime,Confident,A little,Expert,Confident,Confident
+No,IDSE (master),"R, Github, SQL, RStudio, ggplot2, shell (terminal / command line), Python, regular expressions (grep), dropbox, google drive (formerly docs)",Confident,he/him,vi/vim,Confident,A little,Expert,A little,Confident
+No,IDSE (master),"Matlab, R, Excel, SQL, RStudio, shell (terminal / command line), C/C++, Python, dropbox",Confident,he/him,RStudio,Confident,A little,A little,Confident,A little
+No,IDSE (master),"R, Excel, SQL, RStudio, C/C++, dropbox, google drive (formerly docs)",Confident,he/him,RStudio,A little,A little,A little,None,None
+No,Data Science Certification,"Matlab, R, Excel, SQL, RStudio, shell (terminal / command line), Python, Stata, dropbox, google drive (formerly docs)",Confident,he/him,RStudio,A little,None,None,Confident,None
+Yes,Statistics (master),"R, Excel, RStudio, LaTeX, google drive (formerly docs)",Confident,she/her,RStudio,Confident,Confident,None,A little,A little
+No,IDSE (master),"R, Github, Excel, SQL, RStudio, ggplot2, Python, Web: html css js, dropbox, google drive (formerly docs)",Confident,he/him,RStudio,Confident,Confident,A little,None,Confident
+Yes,Statistics (master),"Matlab, R, RStudio, SPSS, C/C++",Confident,he/him,RStudio,Confident,Confident,A little,Confident,A little
+No,IDSE (master),"Matlab, R, Github, Excel, RStudio, ggplot2, shell (terminal / command line), Python, LaTeX, google drive (formerly docs)",Confident,he/him,RStudio,A little,A little,A little,Confident,Confident
+No,IDSE (master),"Matlab, R, Github, Excel, RStudio, ggplot2, shell (terminal / command line), Python, LaTeX, google drive (formerly docs)",Confident,he/him,RStudio,A little,A little,A little,Confident,Confident
+Yes,Statistics (master),"Matlab, R, Excel, RStudio, SPSS, C/C++",Expert,she/her,RStudio,Expert,Confident,A little,A little,A little
+No,IDSE (master),"R, Github, RStudio, Python, dropbox, google drive (formerly docs)",A little,he/him,RStudio,A little,A little,A little,A little,A little
+No,IDSE (master),"Matlab, R, Excel, SQL, RStudio, Python, dropbox, google drive (formerly docs)",Expert,he/him,RStudio,Confident,Confident,A little,A little,None
+Yes,Statistics (master),"R, RStudio",Confident,she/her,RStudio,A little,A little,None,None,None
+Yes,Statistics (master),"Matlab, R, Github, Excel, SQL, RStudio, ggplot2, C/C++, Python, XML, google drive (formerly docs)",Expert,he/him,RStudio,Confident,Expert,A little,Expert,Confident
+No,IDSE (master),"R, Excel, SQL, RStudio, Python, Stata, google drive (formerly docs)",Confident,she/her,RStudio,Confident,Confident,A little,A little,None
+No,IDSE (master),"Matlab, R, Excel, RStudio, Python, dropbox, google drive (formerly docs)",Confident,he/him,RStudio,A little,A little,Confident,A little,None
+No,IDSE (master),"Excel, Python, dropbox, google drive (formerly docs)",A little,she/her,ipython,None,None,A little,None,None
+No,Data Science Certification,"Matlab, R, Github, Excel, SQL, RStudio, shell (terminal / command line), Python, XML, Web: html css js, dropbox, google drive (formerly docs)",A little,he/him,vi/vim,A little,A little,None,A little,A little
+No,IDSE (master),"R, Python",A little,he/him,vi/vim,A little,A little,A little,A little,A little
+No,Statistics (master),"R, RStudio, ggplot2, LaTeX",A little,he/him,RStudio,A little,None,None,None,None
+No,IDSE (master),"Matlab, R, RStudio, SPSS, Sweave/knitr",Confident,she/her,RStudio,A little,A little,Confident,Confident,None
+Yes,Statistics (master),"R, Github, RStudio, LaTeX, dropbox, google drive (formerly docs)",A little,he/him,RStudio,A little,A little,A little,A little,A little
+No,IDSE (master),"R, Excel, SQL, RStudio, shell (terminal / command line), Python, regular expressions (grep)",Confident,he/him,notepad++,A little,A little,Confident,Confident,A little
+Yes,Ph.D.,"Matlab, R, RStudio, ggplot2, dropbox",Confident,he/him,RStudio,Confident,A little,None,A little,None
+No,IDSE (master),"R, Excel, RStudio, Python, dropbox, google drive (formerly docs)",Confident,she/her,RStudio,A little,A little,A little,None,None
+No,Data Science Certification,"R, SQL, RStudio, shell (terminal / command line), C/C++, Python, dropbox, google drive (formerly docs)",Confident,he/him,RStudio,A little,A little,Confident,A little,A little
+Yes,Statistics (master),"Matlab, R, Excel, SQL, RStudio, ggplot2, C/C++, Web: html css js, dropbox, google drive (formerly docs)",Expert,he/him,RStudio,Confident,Confident,Confident,Confident,A little
+No,IDSE (master),"R, Github, SQL, RStudio, ggplot2, shell (terminal / command line), C/C++, Python, regular expressions (grep), Web: html css js, dropbox, google drive (formerly docs)",Confident,he/him,vi/vim,A little,A little,None,None,Confident
+No,Data Science Certification,"Matlab, R, Excel, SQL, RStudio, ggplot2, shell (terminal / command line), C/C++, Python, regular expressions (grep), XML, Web: html css js, dropbox, google drive (formerly docs)",Expert,she/her,notepad++,Confident,A little,A little,A little,A little
+No,IDSE (master),"R, Github, SQL, RStudio, shell (terminal / command line), C/C++, Python, LaTeX, regular expressions (grep), XML, dropbox, google drive (formerly docs)",Confident,he/him,vi/vim,A little,A little,None,None,Confident
+No,Statistics (master),"Excel, Python, dropbox",A little,he/him,vi/vim,None,None,None,None,A little
+No,IDSE (master),"Matlab, R, RStudio, Python, LaTeX, google drive (formerly docs)",Confident,she/her,RStudio,A little,A little,None,A little,A little
+No,IDSE (master),"Excel, google drive (formerly docs)",None,she/her,vi/vim,None,None,None,A little,A little
+No,Data Science Certification,"R, Excel, SQL, dropbox, google drive (formerly docs)",Confident,she/her,RStudio,A little,A little,Confident,None,A little
+No,Data Science Certification,"Excel, Python, google drive (formerly docs)",None,he/him,ipython,None,None,None,None,None
+No,Data Science Certification,"Github, Excel, SQL, shell (terminal / command line), C/C++, Python, regular expressions (grep), google drive (formerly docs)",None,he/him,vi/vim,None,None,None,None,Confident
+No,IDSE (master),"R, Github, Excel, SQL, RStudio, ggplot2, shell (terminal / command line), SPSS, Python, Stata, LaTeX, Sweave/knitr, Web: html css js, dropbox, google drive (formerly docs)",Expert,he/him,RStudio,Expert,Confident,Expert,Confident,Confident
+No,Ph.D.,"R, Github, Excel, SQL, shell (terminal / command line), Python, LaTeX, Web: html css js, dropbox, google drive (formerly docs)",A little,he/him,vi/vim,A little,None,None,None,Confident
+Yes,Other masters,"R, Github, Excel, SQL, RStudio, ggplot2, shell (terminal / command line), LaTeX, regular expressions (grep), Sweave/knitr, dropbox, google drive (formerly docs)",Expert,he/him,RStudio,A little,A little,A little,None,A little
+No,Other masters,"Github, shell (terminal / command line), C/C++, Python, LaTeX",None,he/him,Sublime,None,None,A little,None,Confident
+No,IDSE (master),"R, Excel, SQL, RStudio, shell (terminal / command line), Python, LaTeX, dropbox, google drive (formerly docs)",A little,he/him,RStudio,A little,A little,Confident,None,None
+No,Data Science Certification,"Excel, Python, dropbox, google drive (formerly docs)",Confident,he/him,Sublime,None,A little,None,A little,A little
+No,IDSE (master),"R, Github, Excel, SQL, RStudio, shell (terminal / command line), Python, LaTeX, Web: html css js, dropbox, google drive (formerly docs)",Confident,she/her,Sublime,None,A little,Confident,None,Confident
+No,IDSE (master),"Matlab, R, Excel, RStudio, C/C++, Python",A little,he/him,RStudio,A little,A little,None,A little,None
+Yes,Other masters,"Matlab, Excel, C/C++, Python",A little,he/him,TextWrangler,A little,A little,A little,A little,A little
+Yes,Statistics (master),"R, Github",A little,she/her,RStudio,None,None,None,None,A little
+No,Other masters,"R, Excel, RStudio, dropbox, google drive (formerly docs)",Confident,she/her,RStudio,A little,A little,None,None,None
+No,IDSE (master),"Github, Excel, SQL, RStudio, shell (terminal / command line), Python, Web: html css js, dropbox, google drive (formerly docs)",A little,he/him,"Atom, Sublime",A little,A little,A little,A little,A little
+No,IDSE (master),"Excel, RStudio, Python, dropbox, google drive (formerly docs)",A little,he/him,RStudio,A little,A little,A little,A little,None
+No,IDSE (master),"Matlab, Github, Excel, SQL, shell (terminal / command line), C/C++, Python, regular expressions (grep), XML, Web: html css js, dropbox, google drive (formerly docs)",None,he/him,Any,None,None,None,Confident,A little
+No,IDSE (master),"R, Github, Excel, SQL, RStudio, shell (terminal / command line), C/C++, Python, regular expressions (grep), XML, Web: html css js, dropbox, google drive (formerly docs)",Confident,she/her,Sublime,None,None,Confident,Confident,Confident
+No,IDSE (master),"Matlab, R",A little,he/him,RStudio,None,None,None,A little,None
+No,Data Science Certification,"Github, Excel, SQL, dropbox, google drive (formerly docs)",None,she/her,notepad++,None,None,None,None,A little
+No,Data Science Certification,"Excel, shell (terminal / command line), Python, google drive (formerly docs)",None,he/him,Sublime,None,None,None,None,A little
+No,Data Science Certification,"R, Excel, RStudio, dropbox, google drive (formerly docs)",Confident,she/her,RStudio,A little,A little,Confident,None,A little
+No,IDSE (master),"Matlab, R, Excel, RStudio, Python, dropbox",Confident,she/her,RStudio,A little,None,A little,None,A little
+No,Data Science Certification,"Github, Excel, SQL, RStudio, Python, dropbox, google drive (formerly docs)",A little,he/him,Sublime,None,None,None,None,Confident
+No,IDSE (master),"R, Github, Excel, SQL, RStudio, shell (terminal / command line), C/C++, LaTeX, regular expressions (grep), Sweave/knitr, XML, Web: html css js, dropbox, google drive (formerly docs)",A little,he/him,Sublime,A little,A little,A little,None,Expert
+No,Data Science Certification,"R, Github, Excel, RStudio, Python, google drive (formerly docs)",A little,he/him,ipython,A little,None,None,A little,A little
+No,Data Science Certification,"SQL, shell (terminal / command line), C/C++, Python",A little,he/him,vi/vim,None,None,None,A little,A little
+No,Data Science Certification,"R, Excel, SQL, Python, Stata, LaTeX, Web: html css js, google drive (formerly docs)",A little,he/him,notepad++,None,None,None,None,None
+No,Ph.D.,"R, Excel, RStudio, shell (terminal / command line), Python, Stata, regular expressions (grep), dropbox, google drive (formerly docs)",Confident,she/her,TextMate,A little,A little,None,None,A little
+No,Data Science Certification,"R, Excel, RStudio, ggplot2, Python, dropbox",Confident,Other,RStudio,A little,A little,None,None,A little
+No,Data Science Certification,"Matlab, R, Github, Excel, SQL, RStudio, shell (terminal / command line), Python, Stata, XML, dropbox, google drive (formerly docs)",A little,he/him,Sublime,A little,A little,A little,Confident,Confident
+No,Data Science Certification,"shell (terminal / command line), Python, regular expressions (grep), Web: html css js",A little,he/him,"Webstorm, pycharm",None,None,None,None,Expert
+No,Other masters,"Matlab, R, Github, Excel, SQL, RStudio, ggplot2, shell (terminal / command line), C/C++, Python, regular expressions (grep), Web: html css js, dropbox, google drive (formerly docs)",Confident,he/him,Sublime,Confident,Confident,Confident,Confident,Confident
+No,IDSE (master),"R, Excel, SQL, C/C++, dropbox, google drive (formerly docs)",A little,he/him,notepad++,None,None,None,None,A little
+No,Other masters,"Matlab, R, Excel, SQL, RStudio, SPSS, Python, Stata, dropbox",Confident,he/him,notepad++,Confident,Confident,Confident,Confident,A little
+No,IDSE (master),"Matlab, R, Github, SQL, ggplot2, shell (terminal / command line), C/C++, Python, LaTeX, dropbox, google drive (formerly docs)",Confident,he/him,Atom,A little,Confident,None,A little,Confident
+No,IDSE (master),"R, Github, Excel, SQL, RStudio, Python",Confident,he/him,RStudio,A little,Confident,None,Confident,A little
+No,IDSE (master),"R, SQL, RStudio, shell (terminal / command line), Python",A little,he/him,TextWrangler,A little,None,None,None,None
+No,Other masters,"R, Github, Excel, SQL, RStudio, ggplot2, shell (terminal / command line), Python, LaTeX, lattice, Sweave/knitr",Confident,he/him,Sublime,Confident,A little,Confident,None,A little
+No,Data Science Certification,"R, Github, Excel, RStudio, regular expressions (grep), dropbox, google drive (formerly docs)",A little,he/him,RStudio,Confident,A little,Confident,A little,Confident
+No,IDSE (master),"Matlab, R, Github, Excel, SQL, RStudio, ggplot2, shell (terminal / command line), C/C++, Python, Stata, LaTeX, XML, Web: html css js, google drive (formerly docs)",Confident,he/him,RStudio,Confident,Confident,Confident,Confident,Confident
+No,IDSE (master),"R, SQL, RStudio, Python",A little,he/him,TextWrangler,A little,None,None,None,None
+No,Other masters,"R, Github, RStudio",A little,she/her,RStudio,A little,None,A little,None,A little
+No,Data Science Certification,"Github, Excel, SQL, shell (terminal / command line), XML, Web: html css js",None,she/her,Eclipse ,None,None,None,A little,A little
+No,IDSE (master),Python,A little,he/him,Sublime,A little,None,A little,None,A little
+No,IDSE (master),"Matlab, SQL, shell (terminal / command line), Python, LaTeX, Web: html css js",Confident,he/him,vi/vim,A little,A little,A little,Confident,A little


### PR DESCRIPTION
Edited Program, Text Editor, Pronoun columns to make them consistent.
Also removed columns without data.

There will not be any problem to run the rmd file with this file, but need to modify the file name in the code. We can modify the code, if we decide to use this csv file.

These are the changes I made. The numbers are row numbers.
- Program
  36, 13, 105 -> IDSE (master)
  8, 16, 31, 75 -> Other masters
  97 -> Ph.D.
- Text Editor
  6, 31, 35, 75, 86, 92, 93, 99, 107, 113 -> Sublime (from ‘sublime,
  sublime text, sublime text2, etc’)
  23, 31, 52, 70, 94 -> ipython (from Ipython, python, jupiter)
  5, 80, 106, 110 -< TextWrangler (from text wrangler, TextWrangler)
  8 -> None (from haven’t used any)
  85 -> Any (Any (20 years C++/Java experience))
  83 -> Atom, Sublime text (from Atom/Sublime text)
- Pronoun
  8, 98 -> Other (from doesn’t matter and blank)
